### PR TITLE
Make parser support multi-line via `\r\n`

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -5,128 +5,128 @@ var Parser = require('../')
 describe('types', function () {
   it('parses single atom', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1'])
       done()
     })
-    lp.end('TAG1')
+    lp.end('TAG1\r\n')
   })
   it('parses multiple atoms', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', 'UID', 'FETCH'])
       done()
     })
-    lp.end('TAG1 UID FETCH')
+    lp.end('TAG1 UID FETCH\r\n')
   })
   it('parses single quoted', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1'])
       done()
     })
-    lp.end('"TAG1"')
+    lp.end('"TAG1"\r\n')
   })
   it('parses multiword quoted', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1 UID FETCH'])
       done()
     })
-    lp.end('"TAG1 UID FETCH"')
+    lp.end('"TAG1 UID FETCH"\r\n')
   })
   it('parses atom + quoted', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', 'UID FETCH'])
       done()
     })
-    lp.end('TAG1 "UID FETCH"')
+    lp.end('TAG1 "UID FETCH"\r\n')
   })
   it('parses string literal', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', 'ABC DEF\r\nGHI JKL', 'TAG2'])
       done()
     })
-    lp.write('TAG1 {123}')
-    lp.writeLiteral('ABC DEF\r\nGHI JKL')
-    lp.end('"TAG2"')
+    lp.write('TAG1 {16}\r\n')
+    lp.write('ABC DEF\r\nGHI JKL')
+    lp.end('"TAG2"\r\n')
   })
   it('parses NIL value', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', null])
       done()
     })
-    lp.end('TAG1 NIL')
+    lp.end('TAG1 NIL\r\n')
   })
   it('parses NIL string', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', 'NIL'])
       done()
     })
-    lp.end('TAG1 "NIL"')
+    lp.end('TAG1 "NIL"\r\n')
   })
 })
 
 describe('structure', function () {
   it('parses a single group', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', 'FETCH', ['NAME', 'HEADER', 'BODY']])
       done()
     })
-    lp.end('TAG1 FETCH (NAME HEADER BODY)')
+    lp.end('TAG1 FETCH (NAME HEADER BODY)\r\n')
   })
   it('parses a nested group', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', 'FETCH', ['NAME', 'HEADER', 'BODY', ['CHARSET', 'UTF-8']]])
       done()
     })
-    lp.end('TAG1 FETCH (NAME HEADER BODY (CHARSET "UTF-8"))')
+    lp.end('TAG1 FETCH (NAME HEADER BODY (CHARSET "UTF-8"))\r\n')
   })
   it('parses single params', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', {value:'BODY', params: ['DATE', 'TEXT']}])
       done()
     })
-    lp.end('TAG1 BODY[DATE TEXT]')
+    lp.end('TAG1 BODY[DATE TEXT]\r\n')
   })
   it('parses partial data', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', {value:'BODY', partial: [122, 456]}])
       done()
     })
-    lp.end('TAG1 BODY[]<122.456>')
+    lp.end('TAG1 BODY[]<122.456>\r\n')
   })
   it('parses mixed params and partial', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', {value:'BODY', params: ['HEADER', 'FOOTER'], partial: [122, 456]}])
       done()
     })
-    lp.end('TAG1 BODY[HEADER FOOTER]<122.456>')
+    lp.end('TAG1 BODY[HEADER FOOTER]<122.456>\r\n')
   })
   it('parses nested params and groups', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', {value:'BODY', params: ['DATE', 'FLAGS', ['\\Seen', '\\Deleted']]}])
       done()
     })
-    lp.end('TAG1 BODY[DATE FLAGS (\\Seen \\Deleted)]')
+    lp.end('TAG1 BODY[DATE FLAGS (\\Seen \\Deleted)]\r\n')
   })
   it('parses bound and unbound params', function (done) {
     var lp = new Parser()
-    lp.on('line', function (data) {
+    lp.on('data', function (data) {
       assert.deepEqual(data, ['TAG1', {params: ['ALERT']}, {value:'BODY', params: ['TEXT', 'HEADER']}])
       done()
     })
-    lp.end('TAG1 [ALERT] BODY[TEXT HEADER]')
+    lp.end('TAG1 [ALERT] BODY[TEXT HEADER]\r\n')
   })
 })
 
@@ -138,6 +138,6 @@ describe('logging', function () {
       done()
     })
     lp.write('TAG1 ')
-    lp.end('FETCH (NAME HEADER BODY)')
+    lp.end('FETCH (NAME HEADER BODY)\r\n')
   })
 })


### PR DESCRIPTION
This makes the library feel more like a typical parsing stream.  The main changes are to include the ability to parse the "string literals" as part of imap-parser and support splitting multiple lines out automatically using `\r\n`.

It also renames the `line` event to `data` as this would allow it to make more sense as a parsing stream in the future.  One `data` event is emitted for each line.

Since it handles multiple lines and string literals internally, you can just `.pipe` the connection stream to it in order to get a parsed version of the connection stream.

I'd love it if @andris9 could review this for whether it would still work with [inbox](https://github.com/andris9/inbox/pull/24)
